### PR TITLE
Fix decimal separator using invariant culture

### DIFF
--- a/src/ACadSharp.Pdf.Tests/PdfExporterTests.cs
+++ b/src/ACadSharp.Pdf.Tests/PdfExporterTests.cs
@@ -1,5 +1,9 @@
+using ACadSharp.Entities;
 using ACadSharp.IO;
+using CSMath;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -53,6 +57,42 @@ namespace ACadSharp.Pdf.Tests
 			PdfExporter exporter = this.getPdfExporter(filename);
 			exporter.AddModelSpace(doc);
 			exporter.Close();
+		}
+
+		[Fact]
+		public void InvariantDecimalSeparatorTest()
+		{
+			CultureInfo previousCulture = CultureInfo.CurrentCulture;
+
+			try
+			{
+				//A culture such as fr-FR uses the comma as decimal separator,
+				//which would produce an invalid pdf stream if numbers were not
+				//formatted using the invariant culture.
+				CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+
+				CadDocument doc = new CadDocument();
+				doc.Entities.Add(new Line(new XYZ(0, 0, 0), new XYZ(12.5, 7.25, 0)));
+
+				string content;
+				using (MemoryStream stream = new MemoryStream())
+				{
+					PdfExporter exporter = new PdfExporter(stream);
+					exporter.AddModelSpace(doc);
+					exporter.Close();
+
+					content = Encoding.ASCII.GetString(stream.ToArray());
+				}
+
+				//No number must use the comma as decimal separator.
+				Assert.DoesNotMatch(@"\d,\d", content);
+				//The decimal point must be used (e.g. MediaBox, coordinates).
+				Assert.Contains(".", content);
+			}
+			finally
+			{
+				CultureInfo.CurrentCulture = previousCulture;
+			}
 		}
 
 		[Theory]

--- a/src/ACadSharp.Pdf/Core/IO/PdfPen.cs
+++ b/src/ACadSharp.Pdf/Core/IO/PdfPen.cs
@@ -7,6 +7,7 @@ using ACadSharp.Tables;
 using CSMath;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -123,7 +124,7 @@ namespace ACadSharp.Pdf.Core.IO
 		{
 			LineWeightType lw = entity.GetActiveLineWeightType();
 			double lwValue = lw.GetLineWeightValue();
-			this._sb.AppendLine($"{lwValue.ToPdfUnit(PdfUnitType.Millimeter)} {PdfKey.LineWidth}");
+			this._sb.AppendLine($"{lwValue.ToPdfUnit(PdfUnitType.Millimeter).ToString(this._configuration.DecimalFormat, CultureInfo.InvariantCulture)} {PdfKey.LineWidth}");
 
 			Color color = entity.GetActiveColor();
 
@@ -322,7 +323,7 @@ namespace ACadSharp.Pdf.Core.IO
 
 		private string toPdfDouble(double value)
 		{
-			return (value / this.DenominatorScale).ToPdfUnit(this.PaperUnits).ToString(this._configuration.DecimalFormat);
+			return (value / this.DenominatorScale).ToPdfUnit(this.PaperUnits).ToString(this._configuration.DecimalFormat, CultureInfo.InvariantCulture);
 		}
 
 		private void writeEntityEnd(Entity entity)

--- a/src/ACadSharp.Pdf/Core/PdfReference.cs
+++ b/src/ACadSharp.Pdf/Core/PdfReference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ACadSharp.Pdf.Core
 {
@@ -20,7 +21,14 @@ namespace ACadSharp.Pdf.Core
 
 		public override string GetPdfForm(PdfConfiguration configuration)
 		{
-			return this._f.Invoke().ToString();
+			T value = this._f.Invoke();
+
+			if (value is IFormattable formattable)
+			{
+				return formattable.ToString(null, CultureInfo.InvariantCulture);
+			}
+
+			return value.ToString();
 		}
 	}
 }

--- a/src/ACadSharp.Pdf/Extensions/XYZExtensions.cs
+++ b/src/ACadSharp.Pdf/Extensions/XYZExtensions.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Pdf.Core;
 using CSMath;
 using System;
+using System.Globalization;
 
 namespace ACadSharp.Pdf.Extensions
 {
@@ -39,7 +40,7 @@ namespace ACadSharp.Pdf.Extensions
 	{
 		public static string ToPdfString(this Color color)
 		{
-			return $"{color.R / 255d} {color.G / 255d} {color.B / 255d} RG";
+			return string.Format(CultureInfo.InvariantCulture, "{0} {1} {2} RG", color.R / 255d, color.G / 255d, color.B / 255d);
 		}
 	}
 }


### PR DESCRIPTION
## Problem

On a machine using a culture where the comma is the decimal separator (e.g. `fr-FR`), the exported PDF appears blank in viewers even though the file is full of drawing commands.

The content stream contains numbers formatted with the current culture:

```
/MediaBox [0 0 471,856 427,000]
...
283,4646 0 l
0,085 w
```

PDF requires the **decimal point** as separator, so `283,4646` is parsed as two invalid tokens and the whole content stream is corrupted, rendering nothing.

## Fix

Force `CultureInfo.InvariantCulture` everywhere a `double` is written to the PDF:

- `PdfPen.toPdfDouble` — entity coordinates
- `PdfPen.applyStyle` — line width
- `PdfReference<T>.GetPdfForm` — MediaBox dimensions (uses `IFormattable` to stay generic)
- `ColorExtensions.ToPdfString` — RGB color components

Note: `PdfContent` already used the invariant culture for the translation matrix, which is why the bug was easy to miss on en-US machines.

## Test

Added a regression test (`InvariantDecimalSeparatorTest`) that exports a simple document under the `fr-FR` culture and asserts that no number uses the comma as decimal separator. It restores the previous culture in a `finally` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)